### PR TITLE
Use AUTH MODE endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This tool is provided to help users move from the Legacy auth environments of Fi
 
 Specifically, it helps facilitate moving organizations and users from an existing Auth0 Tenant to the Internal ecosystem so that user and role information can be preserved.
 
+**This migration script requires Fiftyone Teams version >= 1.7.0**
+
 ## Migrating FiftyOne Teams to internal mode
 
 See the [migration workflow](./migration-workflow.md) document for instructions on how to use this repository to migrate your FiftyOne Teams deployment to `internal` auth mode.
 
 Read more about FiftyOne authentication modes [here](https://docs.voxel51.com/teams/pluggable_auth.html#fiftyone-authentication-modes).
-
-
 
 ## Usage
 
@@ -37,7 +37,6 @@ Set those variables for your current terminal session by running the following f
 ```
 export $(grep -v '^#' .env | xargs)
 ```
-
 
 After the environment variables for this repository have been set, you are ready to run the migration script.
 

--- a/cas_helpers/__init__.py
+++ b/cas_helpers/__init__.py
@@ -1,1 +1,1 @@
-from cas_helpers.cas_methods import add_org, add_user
+from cas_helpers.cas_methods import add_org, add_user, get_auth_mode

--- a/cas_helpers/__init__.py
+++ b/cas_helpers/__init__.py
@@ -1,1 +1,1 @@
-from cas_helpers.cas_methods import add_org, add_user, get_auth_mode
+from cas_helpers.cas_methods import add_org, add_user, get_auth_mode, get_existing_auth_config

--- a/cas_helpers/cas_methods.py
+++ b/cas_helpers/cas_methods.py
@@ -41,3 +41,19 @@ async def get_auth_mode(session):
         print("Unable to connect to CAS with ERROR: ", e, "\n")
         return None
 
+async def get_existing_auth_config(session):
+    async with session.get(f"{CAS_BASE_URL}/config/", headers=HEADERS) as resp:
+        # check if this looks like an auto imported auth0 config
+        if resp.status == 200:
+            info = await resp.json()
+            for provider in info["authenticationProviders"]:
+                id = provider["id"] 
+                org = provider["authorization"]["params"]["organization"]
+                # if the id matches our auto generated and the org id
+                # matches the existing auth0 org id, this is the 
+                # associated one created automatically and can be used.
+                # otherwise, we  want to warn the user to review
+                # their auth config
+                if id == "auth0" and org == Config.ORGANIZATION_ID:
+                    return True
+        return False

--- a/cas_helpers/cas_methods.py
+++ b/cas_helpers/cas_methods.py
@@ -4,8 +4,6 @@ from config import Config
 CAS_BASE_URL = Config.CAS_BASE_URL
 HEADERS = {"X-API-KEY": Config.FIFTYONE_AUTH_SECRET}
 
-session = aiohttp.ClientSession()
-
 
 async def add_org(session, org_data):
     print("Adding Organization...")
@@ -30,4 +28,16 @@ async def add_user(session, user_data):
             "role": user_data["role"]
             }) as resp:
           print(f"Added User {user_data['email']}")
+
+async def get_auth_mode(session):
+    try:
+        async with session.get(f"{CAS_BASE_URL}/config/mode/", headers=HEADERS) as resp:
+            if resp.status != 200:
+                return None
+
+            auth_mode = await resp.json()
+            return auth_mode["mode"]
+    except aiohttp.client_exceptions.ClientConnectorError as e:
+        print("Unable to connect to CAS with ERROR: ", e, "\n")
+        return None
 

--- a/migrate.py
+++ b/migrate.py
@@ -9,7 +9,7 @@ import asyncio
 
 from auth0_helpers import Auth0ManagementAPIFactory, Auth0Manager
 from config import Config
-from cas_helpers import add_org, add_user, get_auth_mode
+from cas_helpers import add_org, add_user, get_auth_mode, get_existing_auth_config
 
 auth0_mgmt_factory = Auth0ManagementAPIFactory(
     Config.CLIENT_DOMAIN,
@@ -57,9 +57,15 @@ async def main():
     # it's internal, green light go!
     if mode == "internal":
         async with aiohttp.ClientSession() as session:
-            # TODO: check for auth config
+            auth_config = await get_existing_auth_config(session)
             await migrate_organization(session)
             await migrate_users(session)
+            if not auth_config:
+                print("==== Warning ====")
+                print("An existing auth configuration was not found")
+                print("or does not match an existing IdP configuration.\n")
+                print("Please review your auth configuration in the provided")
+                print("page at: {your domain}/cas/admins")
 
         print("Migration Complete")
 

--- a/migrate.py
+++ b/migrate.py
@@ -43,7 +43,6 @@ async def main():
         print("Unable to connect to the Central Auth Service (CAS)\n")
         print("Please check your Fiftyone Teams deployment and ensure that")
         print("there is a running CAS at the supplied CAS_BASE_URL\n")
-        return None
 
     # we don't want to run in legacy mode
     if mode == "legacy":


### PR DESCRIPTION
# Rationale

We can supply many useful messages and prevent mistakes if we're aware of the FIFTYONE_AUTH_MODE of the currently running CAS. Now we can prevent the script from running if the CAS is in `legacy` mode, which would end up making a lot of unnecessary calls to Auth0 and wouldn't migrate anything.

# Changes

Uses the CAS API to check the current state of FIFTYONE_AUTH_MODE, then only run the migrations if in `internal` mode. Additionally, supplied many more messages to the user to help guide usage of the script.

# Testing
Using a build of CAS that includes the exposed auth mode endpoint, run the script in three cases:

- CAS isn't running
    - script should exit gracefully with a message and take no action
- CAS is running in legacy mode
    - script should exit gracefully with an alert and take no action
- CAS is running in internal mode
    - scirpt should run as expected